### PR TITLE
Define min width for the body before becoming scrollable in the x axis

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 * {
   margin: 0;
   padding: 0;
+  box-sizing: border-box; /* Ensures padding & borders don't increase width */
 }
 
 :root {
@@ -14,9 +15,16 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  min-width: 316px;
+  overflow-x: auto;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+#root {
+  width: 100%;
+}
+


### PR DESCRIPTION
Define min width for the body before becoming scrollable in the x axis and ensure root div uses 100% of all body width