### PR TITLE
Broke css flex properties into its own class

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -79,11 +79,13 @@ function SocialMedia() {
 export default function Footer() {
   return (
     <footer className="footer-navigation constrain-content outline">
-      <div className="flex-row full-width wrap-footer center-items outline">
-        <LittleLemonLogo />
-        <DoormatNavigation />
-        <Contact />
-        <SocialMedia />
+      <div className="flex-column justify-center full-height">
+        <div className="flex-row justify-between full-width wrap-footer center-items outline">
+          <LittleLemonLogo />
+          <DoormatNavigation />
+          <Contact />
+          <SocialMedia />
+        </div>
       </div>
     </footer>
   );

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -46,7 +46,7 @@ function DesktopHeader() {
 export default function Header() {
   return (
     <header className="navigation-bar constrain-content outline">
-      <div className="flex-row full-height center-items outline ">
+      <div className="flex-row justify-between full-height center-items outline ">
         <HorizontalLayout>
           <DesktopHeader />
           <MobileHeader />

--- a/src/Components/Main/HeroSection.js
+++ b/src/Components/Main/HeroSection.js
@@ -58,7 +58,7 @@ function MobileHeroSection() {
     <div className="outline">
       <RestaurantTitles />
       <div className="flex-row start-items">
-        <div className="flex-column">
+        <div className="flex-column justify-between">
           <RestaurantAppealAction />
         </div>
         <RestaurantImage />

--- a/src/styles/helpers.css
+++ b/src/styles/helpers.css
@@ -1,3 +1,6 @@
+@import url("dimensions.css");
+
+/* Dimensions */
 .outline {
   border: 1px solid black;
 }
@@ -10,16 +13,40 @@
   width: 100%;
 }
 
+/* Flexbox */
+
 .flex-row {
   display: flex;
-  justify-content: space-between;
 }
 
 .flex-column {
   display: flex;
   flex-direction: column;
+}
+
+/* Flexbox - Justify Content */
+
+.justify-between {
   justify-content: space-between;
 }
+
+.justify-around {
+  justify-content: space-around;
+}
+
+.justify-start {
+  justify-content: flex-start;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-end {
+  justify-content: flex-end;
+}
+
+/* Flexbox - Align items */
 
 .center-items {
   align-items: center;
@@ -27,4 +54,54 @@
 
 .start-items {
   align-items: self-start;
+}
+
+.self-start {
+  align-self: self-start;
+}
+
+.self-center {
+  align-self: center;
+}
+
+.self-end {
+  align-self: flex-end;
+}
+
+/* Margins - Vertical */
+
+.vertical-tmargin-12 {
+  margin-top: var(--spacing-12);
+}
+
+.vertical-tmargin-24 {
+  margin-top: var(--spacing-24);
+}
+
+.vertical-tmargin-40 {
+  margin-top: var(--spacing-40);
+}
+
+.vertical-bmargin-40 {
+  margin-bottom: var(--spacing-40);
+}
+
+/* Margins - Horizontal */
+
+.horizontal-lmargin-4 {
+  margin-left: var(--spacing-4);
+}
+
+/* Paddings - Vertical */
+
+.vertical-padding-20 {
+  padding-top: var(--spacing-20);
+  padding-bottom: var(--spacing-20);
+}
+
+/* Paddings - Horizontal */
+
+.horizontal-padding-12 {
+  padding-left: var(--spacing-12);
+  padding-right: var(--spacing-12);
 }


### PR DESCRIPTION
To create more reusable css classes some flexbox properties were broken down into different classes, which allowed to reuse classes without needing to overwrite or create a similar css rule with a different value for the property. Also some code cleaning was done to make helpers.css file more readable