### PR TITLE
Remove css imports from main

### DIFF
--- a/src/Components/Main/Main.js
+++ b/src/Components/Main/Main.js
@@ -1,6 +1,3 @@
-import "../../styles/landing.css";
-import "../../styles/helpers.css";
-
 import HeroSection from "./HeroSection";
 import HighlightsSection from "./HighlightsSection";
 


### PR DESCRIPTION
To prevent calling import again of css files already imported in the App component, Main no longer imports common css files used by all components.