### PR TITLE
Ignore all generated files from jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+#JSDoc generated documents
+docs/
+
 # assets
 /public/assets


### PR DESCRIPTION
Since all files are generated, jsdoc files are not included in the repo.