### PR TITLE
Modified export for JSDoc

### DIFF
--- a/src/Components/HorizontalLayout.js
+++ b/src/Components/HorizontalLayout.js
@@ -5,13 +5,12 @@ import useWindowDimensions from "../Hooks/useWindowDimensions.js";
 
 /**A custom React Component that arranges layout based on the breakpoints provided
  * @constructor
- * @param {Array.ReactNode} children - The different children that are rendered based on the breakpoint. Order them from the biggest breakpoint to the smallest breakpoint,
+ * @param {ReactNode[]} children - The different children that are rendered based on the breakpoint. Order them from the biggest breakpoint to the smallest breakpoint,
  * must always have one more child than the number of breakpoints.
- * @param {Array.number} breakpoints - All the breakpoints that can be applied to the layout, will be copied and sorted in descending order.
+ * @param {number[]} breakpoints - All the breakpoints that can be applied to the layout, will be copied and sorted in descending order.
  * @returns {ReactNode} - The react element chosen based on the breakpoint.
  */
-
-export default function HorizontalLayout({ children, breakpoints }) {
+export function HorizontalLayout({ children, breakpoints }) {
   const { width } = useWindowDimensions();
 
   // Checks if there are at least two children for the breakpoints or the default breakpoint.

--- a/src/Components/Main/HeroSection.js
+++ b/src/Components/Main/HeroSection.js
@@ -1,6 +1,6 @@
 import "../../styles/hero.css";
 
-import HorizontalLayout from "../HorizontalLayout.js";
+import { HorizontalLayout } from "../HorizontalLayout.js";
 
 function RestaurantTitles() {
   return (

--- a/src/Components/Main/HighlightsSection.js
+++ b/src/Components/Main/HighlightsSection.js
@@ -2,7 +2,7 @@ import "../../styles/highlights.css";
 
 import { lg, md } from "../../Constants/sizes";
 
-import HorizontalLayout from "../HorizontalLayout";
+import { HorizontalLayout } from "../HorizontalLayout";
 
 import useWindowDimensions from "../../Hooks/useWindowDimensions";
 


### PR DESCRIPTION
Using default export was not properly naming the custom HorizontalLayout function component in the generated jsdocs and instead was naming the function export, by changing the default export to just export the proper naming convention happened.