### PR TITLE
Removed duplicated css rules

### DIFF
--- a/src/styles/highlights.css
+++ b/src/styles/highlights.css
@@ -1,61 +1,21 @@
 @import url("colors.css");
 @import url("dimensions.css");
 
-@media (width < 768px) {
-  .scroll-container {
-    width: 100%;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
+/* @media (width < 768px) {} */
 
-  .scrollx-content {
-    display: inline-flex;
-    flex-wrap: nowrap;
-    gap: var(--spacing-32);
-  }
+/* @media (768px <= width <= 1200px) {} */
 
-  .scroll-x {
-    width: 100%;
-    overflow-x: scroll;
-  }
+/* @media (width > 1200px) {} */
+
+.scroll-container {
+  width: 100%;
+  overflow-x: auto;
 }
 
-@media (768px <= width <= 1200px) {
-  .scroll-container {
-    width: 100%;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  .scrollx-content {
-    display: inline-flex;
-    flex-wrap: nowrap;
-    gap: var(--spacing-32);
-  }
-
-  .scroll-x {
-    width: 100%;
-    overflow-x: scroll;
-  }
-}
-
-@media (width > 1200px) {
-  .scroll-container {
-    width: 100%;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  .scrollx-content {
-    display: inline-flex;
-    flex-wrap: nowrap;
-    gap: var(--spacing-32);
-  }
-
-  .scroll-x {
-    width: 100%;
-    overflow-x: scroll;
-  }
+.scrollx-content {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: var(--spacing-32);
 }
 
 .specials-title {


### PR DESCRIPTION
Scroll container rules were being duplicated in each of the media query breakpoints so instead the classes were only used once outside any media query.