### PR TITLE
Reduce duplicated css code

### DIFF
--- a/src/styles/highlights.css
+++ b/src/styles/highlights.css
@@ -7,14 +7,7 @@
 
 /* @media (width > 1200px) {} */
 
-.scroll-container {
-  width: 100%;
-  overflow-x: auto;
-}
-
-.scrollx-content {
-  display: inline-flex;
-  flex-wrap: nowrap;
+.highlights .scrollx-content {
   gap: var(--spacing-32);
 }
 

--- a/src/styles/testimonials.css
+++ b/src/styles/testimonials.css
@@ -25,14 +25,7 @@
   align-items: center;
 }
 
-.scroll-container {
-  width: 100%;
-  overflow-x: auto;
-}
-
-.scrollx-content {
-  display: inline-flex;
-  flex-wrap: nowrap;
+.testimonials .scrollx-content {
   gap: var(--spacing-20);
 }
 


### PR DESCRIPTION
Add just the properties required when using the scroll-container and scrollx-content by using css selector specificity.