### PR TITLE
Add unique keys to loop child components

### DIFF
--- a/src/Components/Main/AboutSection.js
+++ b/src/Components/Main/AboutSection.js
@@ -20,6 +20,7 @@ export default function AboutSection() {
           <div className="about-founder-portraits full-width">
             {[1, 2].map((v) => (
               <img
+                key={v}
                 src="/assets/images/founder.png"
                 alt="Founder of Restaurant portrait"
               />

--- a/src/Components/Main/TestimonialsSection.js
+++ b/src/Components/Main/TestimonialsSection.js
@@ -12,14 +12,26 @@ function StarRating({ rating }) {
   return (
     <>
       {range(0, filledStarCount, 1).map((v) => (
-        <img src="/assets/svgs/filled-star.svg" alt="Filled Star" />
+        <img
+          key={`filled-${v}`}
+          src="/assets/svgs/filled-star.svg"
+          alt="Filled Star"
+        />
       ))}
       {hasHalfFilledStar && (
-        <img src="/assets/svgs/half-filled-star.svg" alt="Filled Star" />
+        <img
+          key="half-filled-1"
+          src="/assets/svgs/half-filled-star.svg"
+          alt="Filled Star"
+        />
       )}
       {range(0, 5 - filledStarCount - (hasHalfFilledStar ? 1 : 0), 1).map(
         (v) => (
-          <img src="/assets/svgs/empty-star.svg" alt="Filled Star" />
+          <img
+            key={`empty-${v}`}
+            src="/assets/svgs/empty-star.svg"
+            alt="Filled Star"
+          />
         )
       )}
     </>


### PR DESCRIPTION
To prevent error of components not having unique keys when rendered through an array map, all childs now contain unique keys, note that the keys are index positions hence not appropriate for changing the order.