### PR TITLE
Fix React uncontrolled input warning

### DIFF
--- a/src/Components/Common/Inputs/CustomSelect.js
+++ b/src/Components/Common/Inputs/CustomSelect.js
@@ -24,7 +24,6 @@ export default function CustomSelect({
       <select
         className={`${"paragraph-text"} ${className}`}
         name={name}
-        defaultValue={defaultOption.value}
         value={selectValue}
         onChange={handleOnChange}
       >


### PR DESCRIPTION
React requires that any default value be declared before and passed to the value property instead of using html property default-value.