### PR TITLE
Centralize css rules for inputs

### DIFF
--- a/src/Components/Common/Inputs/CustomDate.js
+++ b/src/Components/Common/Inputs/CustomDate.js
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 
 import "../../../styles/fonts.css";
 import "../../../styles/inputs/custom-date.css";
+import "../../../styles/inputs/input.css";
 
 export default function CustomDate({
   name,
@@ -21,7 +22,7 @@ export default function CustomDate({
       ) {
         ref.current.showPicker();
       } else {
-        console.warn("shoPicker() is not supported by the browser");
+        console.warn("showPicker() is not supported by the browser");
       }
     } catch (error) {
       console.error("There was an error calling showPicker():", error);
@@ -42,19 +43,19 @@ export default function CustomDate({
   const minFormattedDate = (minDate || value).toISOString().slice(0, 10);
   const maxFormattedDate = maxDate.toISOString().slice(0, 10);
   return (
-    <div className="date-wrapper">
+    <div className="input-wrapper">
       {icon}
       <input
         name={name}
-        className="paragraph-text"
+        className="paragraph-text custom-input"
         type="date"
         ref={ref}
         value={curFormattedDate}
         onChange={handleOnChange}
-        min={minFormattedDate}
-        max={maxFormattedDate}
         onClick={handleOpenPicker}
         onKeyDown={handleKeyDown}
+        min={minFormattedDate}
+        max={maxFormattedDate}
       />
     </div>
   );

--- a/src/Components/Common/Inputs/CustomSelect.js
+++ b/src/Components/Common/Inputs/CustomSelect.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import "../../../styles/fonts.css";
 import "../../../styles/inputs/custom-select.css";
+import "../../../styles/inputs/input.css";
 
 export default function CustomSelect({
   name,
@@ -19,10 +20,10 @@ export default function CustomSelect({
   }
 
   return (
-    <div className="select-wrapper">
+    <div className="input-wrapper">
       {icon}
       <select
-        className={`${"paragraph-text"} ${className}`}
+        className={`${"paragraph-text custom-input"} ${className}`}
         name={name}
         value={selectValue}
         onChange={handleOnChange}

--- a/src/Components/Common/Inputs/CustomTime.js
+++ b/src/Components/Common/Inputs/CustomTime.js
@@ -33,11 +33,11 @@ export default function CustomTime({ name, value, onChange, min, max, icon }) {
 
   console.log("Value", value);
   return (
-    <div className="time-wrapper">
+    <div className="input-wrapper">
       {icon}
       <input
         name={name}
-        className="paragraph-text"
+        className="paragraph-text custom-input"
         type="time"
         ref={ref}
         value={value}

--- a/src/styles/inputs/custom-date.css
+++ b/src/styles/inputs/custom-date.css
@@ -1,50 +1,6 @@
 @import url("../colors.css");
 
-.date-wrapper {
-  height: 48px;
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  border-radius: 8px;
-  background-color: transparent;
-}
-
 /* Fully hide the default calendar dropdown */
-.date-wrapper input[type="date"]::-webkit-calendar-picker-indicator {
+input[type="date"]::-webkit-calendar-picker-indicator {
   display: none;
-}
-
-.date-wrapper input {
-  outline: none;
-  width: 100%;
-  height: 48px;
-  border-radius: 8px;
-  border: 0 solid transparent;
-  background-color: var(--highlight-1);
-  cursor: pointer;
-  padding-left: 2.5rem;
-  padding-right: 1rem;
-  appearance: none;
-  color: var(--primary-1);
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-  transition: box-shadow 0.3s ease-in-out;
-}
-
-.date-wrapper select:hover {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.date-wrapper select:focus {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.date-wrapper select:active {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
 }

--- a/src/styles/inputs/custom-select.css
+++ b/src/styles/inputs/custom-select.css
@@ -1,59 +1,5 @@
 @import url("../colors.css");
 
-.select-wrapper {
-  height: 48px;
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  border-radius: 8px;
-}
-
-.select-wrapper select {
-  outline: none;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  border: 0 solid transparent;
-  background-color: var(--highlight-1);
-  cursor: pointer;
-  padding-left: 2.5rem;
-  padding-right: 1rem;
-  appearance: none;
-  color: var(--primary-1);
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-  transition: box-shadow 0.3s ease-in-out;
-}
-
-.select-wrapper select:hover {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.select-wrapper select:focus {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.select-wrapper select:active {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.select-icon {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  left: 16px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--primary-1);
-  pointer-events: none;
-}
-
 .chevron-icon {
   position: absolute;
   right: 16px;

--- a/src/styles/inputs/custom-time.css
+++ b/src/styles/inputs/custom-time.css
@@ -1,50 +1,6 @@
 @import url("../colors.css");
 
-.time-wrapper {
-  height: 48px;
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  border-radius: 8px;
-  background-color: transparent;
-}
-
 /* Fully hide the default calendar dropdown */
-.time-wrapper input[type="time"]::-webkit-calendar-picker-indicator {
+input[type="time"]::-webkit-calendar-picker-indicator {
   display: none;
-}
-
-.time-wrapper input {
-  outline: none;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  border: 0 solid transparent;
-  background-color: var(--highlight-1);
-  cursor: pointer;
-  padding-left: 2.5rem;
-  padding-right: 1rem;
-  appearance: none;
-  color: var(--primary-1);
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-  transition: box-shadow 0.3s ease-in-out;
-}
-
-.time-wrapper select:hover {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.time-wrapper select:focus {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-}
-
-.time-wrapper select:active {
-  outline: none;
-  /* stylelint-disable-next-line color-function-notation  -- required opacity */
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
 }

--- a/src/styles/inputs/input.css
+++ b/src/styles/inputs/input.css
@@ -1,0 +1,55 @@
+@import url("../colors.css");
+
+.input-wrapper {
+  height: 48px;
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  border-radius: 8px;
+}
+
+.custom-input {
+  outline: none;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 0 solid transparent;
+  background-color: var(--highlight-1);
+  color: var(--primary-1);
+  cursor: pointer;
+  padding-left: 2.5rem;
+  padding-right: 1rem;
+  appearance: none;
+  /* stylelint-disable-next-line color-function-notation  -- required opacity */
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  transition: box-shadow 0.3s ease-in-out;
+}
+
+.custom-input:hover {
+  outline: none;
+  /* stylelint-disable-next-line color-function-notation  -- required opacity */
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
+}
+
+.custom-input:focus {
+  outline: none;
+  /* stylelint-disable-next-line color-function-notation  -- required opacity */
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
+}
+
+.custom-input:active {
+  outline: none;
+  /* stylelint-disable-next-line color-function-notation  -- required opacity */
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
+}
+
+.custom-input-icon {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-1);
+  pointer-events: none;
+}


### PR DESCRIPTION
To avoid duplicating css rules with different styles an input.css file was created that centralizes all rules into a single file and the rules were removed from the other files. The Components were updated with the new class names to avoid issues.