### PR TITLE
Fixed issue in screens between 1200px and 1440px that displayed two inputs per row

### DIFF
--- a/src/styles/reserve/reservation.css
+++ b/src/styles/reserve/reservation.css
@@ -79,8 +79,8 @@
   }
 
   .custom-select-subsection-grid {
-    grid-template-columns: repeat(auto-fit, minmax(281px, 1fr));
-    gap: var(--spacing-16);
+    grid-template-columns: repeat(auto-fit, minmax(236px, 1fr));
+    gap: var(--spacing-8);
   }
 
   .time-window-subsection-grid {


### PR DESCRIPTION
The default behavior on desktop screens should be to display three inputs per row for the custom select subsection so the minimum range was decreased in the column grid layout to allow three inputs to be in the same row when in desktop.