### PR TITLE
Split css value into a second class

### DIFF
--- a/src/Components/Common/Inputs/BaseInput.js
+++ b/src/Components/Common/Inputs/BaseInput.js
@@ -24,7 +24,9 @@ export default function BaseInput({
         {icon}
         {children}
       </div>
-      {touched && error && <p className="input-error">{error}</p>}
+      {touched && error && (
+        <p className="input-error left-padding-16">{error}</p>
+      )}
     </div>
   );
 }

--- a/src/styles/helpers.css
+++ b/src/styles/helpers.css
@@ -217,6 +217,10 @@ li a:visited {
   padding-right: var(--spacing-16);
 }
 
+.left-padding-16 {
+  padding-left: var(--spacing-16);
+}
+
 /* Border - Radius */
 .border-top-radius-8 {
   border-top-left-radius: var(--spacing-8);
@@ -240,6 +244,11 @@ button {
   border-radius: 16px;
   color: black;
   background-color: var(--primary-2);
+}
+
+button:active {
+  background-color: var(--primary-1);
+  color: white;
 }
 
 button:disabled {

--- a/src/styles/inputs/input.css
+++ b/src/styles/inputs/input.css
@@ -75,6 +75,6 @@
   font-style: normal;
   font-size: 1rem;
   color: var(--secondary-1);
-  padding-left: 1rem;
   margin-top: var(--spacing-4);
 }
+


### PR DESCRIPTION
To use the error style in other type of inputs the padding was split into its own css class and moved to the helpers.css file.