### PR TITLE
Add submitted flag and ariaLabel props to the custom inputs

### DIFF
--- a/src/Components/Common/Inputs/BaseInput.js
+++ b/src/Components/Common/Inputs/BaseInput.js
@@ -14,6 +14,7 @@ import "../../../styles/inputs/input.css";
 export default function BaseInput({
   icon,
   touched,
+  submitted,
   error,
   children,
   className,
@@ -24,7 +25,7 @@ export default function BaseInput({
         {icon}
         {children}
       </div>
-      {touched && error && (
+      {(touched || submitted) && error && (
         <p className="input-error left-padding-16">{error}</p>
       )}
     </div>

--- a/src/Components/Common/Inputs/CustomDate.js
+++ b/src/Components/Common/Inputs/CustomDate.js
@@ -37,6 +37,8 @@ export default function CustomDate({
   className,
   error,
   touched,
+  submitted,
+  ariaLabel,
 }) {
   const ref = useRef(null);
   const { handleOpenPicker, handleKeyDown } = useOpenPicker(ref);
@@ -46,7 +48,12 @@ export default function CustomDate({
   }
 
   return (
-    <BaseInput icon={icon} touched={touched} error={error}>
+    <BaseInput
+      icon={icon}
+      touched={touched}
+      submitted={submitted}
+      error={error}
+    >
       <input
         name={name}
         id={id || name}
@@ -62,6 +69,7 @@ export default function CustomDate({
         onKeyDown={handleKeyDown}
         min={min}
         max={max}
+        aria-label={ariaLabel}
       />
     </BaseInput>
   );

--- a/src/Components/Common/Inputs/CustomSelect.js
+++ b/src/Components/Common/Inputs/CustomSelect.js
@@ -33,13 +33,15 @@ export default function CustomSelect({
   className,
   error,
   touched,
+  submitted,
+  ariaLabel,
 }) {
   function handleOnChange(event) {
     onChange(event);
   }
 
   return (
-    <BaseInput icon={icon} touched={touched} error={error}>
+    <BaseInput icon={icon} touched={touched} submitted={submitted} error={error}>
       <select
         className={`paragraph-text custom-input ${
           icon && "with-icon"
@@ -49,6 +51,7 @@ export default function CustomSelect({
         value={value || options[0].value}
         onChange={handleOnChange}
         onBlur={onBlur}
+        aria-label={ariaLabel}
       >
         {options.map((option, idx) => (
           <option key={option.value} value={option.value} disabled={idx === 0}>

--- a/src/Components/Common/Inputs/CustomText.js
+++ b/src/Components/Common/Inputs/CustomText.js
@@ -35,13 +35,15 @@ export default function CustomText({
   className,
   error,
   touched,
+  submitted,
+  ariaLabel,
 }) {
   function handleOnChange(event) {
     onChange(event);
   }
 
   return (
-    <BaseInput icon={icon} touched={touched} error={error}>
+    <BaseInput icon={icon} touched={touched} submitted={submitted} error={error}>
       <input
         name={name}
         id={id}
@@ -55,6 +57,7 @@ export default function CustomText({
         minLength={min}
         maxLength={max}
         placeholder={placeholder}
+        aria-label={ariaLabel}
       />
     </BaseInput>
   );

--- a/src/Components/Common/Inputs/CustomTextArea.js
+++ b/src/Components/Common/Inputs/CustomTextArea.js
@@ -34,6 +34,7 @@ export default function CustomTextArea({
   className,
   error,
   touched,
+  ariaLabel,
 }) {
   const ref = useRef(null);
 
@@ -73,6 +74,7 @@ export default function CustomTextArea({
         rows={rows}
         cols={cols}
         placeholder={placeholder}
+        aria-label={ariaLabel}
       />
     </BaseInput>
   );

--- a/src/Components/Common/Inputs/CustomTime.js
+++ b/src/Components/Common/Inputs/CustomTime.js
@@ -34,6 +34,8 @@ export default function CustomTime({
   className,
   error,
   touched,
+  submitted,
+  ariaLabel,
 }) {
   const ref = useRef(null);
   const { handleOpenPicker, handleKeyDown } = useOpenPicker(ref);
@@ -43,7 +45,7 @@ export default function CustomTime({
   }
 
   return (
-    <BaseInput icon={icon} touched={touched} error={error}>
+    <BaseInput icon={icon} touched={touched} submitted={submitted} error={error}>
       <input
         name={name}
         id={id}
@@ -59,6 +61,7 @@ export default function CustomTime({
         onKeyDown={handleKeyDown}
         min={min}
         max={max}
+        aria-label={ariaLabel}
       />
     </BaseInput>
   );


### PR DESCRIPTION
As part of changing the UX so the submit button is always enabled, the submitted prop was added to each custom input component since pressing submit could be different from touched. Aria labels were added for both testing and accesibility purposes as it allows to detect the HTML element.