### PR TITLE
Fix case when options was null or empty

### DIFF
--- a/src/Components/Common/Inputs/CustomSelect.js
+++ b/src/Components/Common/Inputs/CustomSelect.js
@@ -41,14 +41,19 @@ export default function CustomSelect({
   }
 
   return (
-    <BaseInput icon={icon} touched={touched} submitted={submitted} error={error}>
+    <BaseInput
+      icon={icon}
+      touched={touched}
+      submitted={submitted}
+      error={error}
+    >
       <select
         className={`paragraph-text custom-input ${
           icon && "with-icon"
         } ${className}`}
         id={id || name}
         name={name}
-        value={value || options[0].value}
+        value={value}
         onChange={handleOnChange}
         onBlur={onBlur}
         aria-label={ariaLabel}


### PR DESCRIPTION
Since value was expecting either the value or the first option of options it could cause issues if the array was undefined or empty since no element existed in the first index position.